### PR TITLE
Ignores eclipse specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 target/
 .DS_Store
+
+# eclipse
+.project
+.classpath
+.settings


### PR DESCRIPTION
Because I personally use eclipse for developing java projects it would be nice if eclipse configuration files and folders ( .project, .classpath, .settings ) would be ignored by GIT.

This pull request adds the above mentioned files and folders to .gitignore
