### PR TITLE
javax.validation.ConstraintDeclarationException when deploying jca-file-store

### DIFF
--- a/files/store/src/main/java/org/connectorz/files/store/GenericManagedConnectionFactory.java
+++ b/files/store/src/main/java/org/connectorz/files/store/GenericManagedConnectionFactory.java
@@ -15,17 +15,24 @@ limitations under the License.
 */
 package org.connectorz.files.store;
 
-import org.connectorz.files.BucketStore;
 import java.io.PrintWriter;
 import java.io.Serializable;
-import java.util.Iterator;
 import java.util.Objects;
 import java.util.Set;
+
 import javax.resource.ResourceException;
-import javax.resource.spi.*;
+import javax.resource.spi.ConfigProperty;
+import javax.resource.spi.ConnectionDefinition;
+import javax.resource.spi.ConnectionManager;
+import javax.resource.spi.ConnectionRequestInfo;
+import javax.resource.spi.ManagedConnection;
+import javax.resource.spi.ManagedConnectionFactory;
 import javax.security.auth.Subject;
-import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 import org.connectorz.files.Bucket;
+import org.connectorz.files.BucketStore;
 
 @ConnectionDefinition(connectionFactory = BucketStore.class,
    connectionFactoryImpl = FileBucketStore.class,
@@ -35,6 +42,8 @@ public class GenericManagedConnectionFactory
         implements ManagedConnectionFactory, Serializable {
 
     private PrintWriter out;
+    @NotNull
+    @Size(min = 1)
     private String rootDirectory;
 
     public GenericManagedConnectionFactory() {
@@ -42,7 +51,6 @@ public class GenericManagedConnectionFactory
         out.println("#GenericManagedConnectionFactory.constructor");
     }
 
-    @Min(1)
     @ConfigProperty(defaultValue = "./store/", supportsDynamicUpdates = true, description = "The root folder of the file store")
     public void setRootDirectory(String rootDirectory) {
         out.println("#FileBucket.setRootDirectory: " + rootDirectory);


### PR DESCRIPTION
The following exception occurs when deploying the jca-file-store RAR.

The reason for this is that in the GenericManagedConnectionFactory the rootDirectory-Setter is annotated with @Min(1).

BeanValidation-Annotations are only allowed at the field or the Getter. In this case even @Min is wrong because this only applies to Numeric-Properties.

Fixing this issue is easy by removing the wrong anotation and annotating the Field rootDirectory with @NotNull and @Size(min = 1).

```
[2014-02-16T16:18:24.303+0100] [glassfish 4.0] [SEVERE] [rardeployment.defaultpoolresourcecreation.failed] [javax.enterprise.resource.resourceadapter.com.sun.enterprise.connectors] [tid: _ThreadID=132 _ThreadName=admin-listener(6)] [timeMillis: 1392563904303] [levelValue: 1000] [[
  RAR7137: Unable to create default resource for the resource-adapter
javax.validation.ConstraintDeclarationException: HV000132: Void methods must not be constrained or marked for cascaded validation, but method public void org.connectorz.files.store.GenericManagedConnectionFactory.setRootDirectory(java.lang.String) is.
    at org.hibernate.validator.internal.metadata.aggregated.rule.VoidMethodsMustNotBeReturnValueConstrained.apply(VoidMethodsMustNotBeReturnValueConstrained.java:33)
    at org.hibernate.validator.internal.metadata.aggregated.ExecutableMetaData$Builder.assertCorrectnessOfConfiguration(ExecutableMetaData.java:439)
    at org.hibernate.validator.internal.metadata.aggregated.ExecutableMetaData$Builder.build(ExecutableMetaData.java:357)
    at org.hibernate.validator.internal.metadata.aggregated.BeanMetaDataImpl$BuilderDelegate.build(BeanMetaDataImpl.java:598)
    at org.hibernate.validator.internal.metadata.aggregated.BeanMetaDataImpl$BeanMetaDataBuilder.build(BeanMetaDataImpl.java:505)
    at org.hibernate.validator.internal.metadata.BeanMetaDataManager.createBeanMetaData(BeanMetaDataManager.java:182)
    at org.hibernate.validator.internal.metadata.BeanMetaDataManager.getBeanMetaData(BeanMetaDataManager.java:142)
    at org.hibernate.validator.internal.engine.ValidatorImpl.getConstraintsForClass(ValidatorImpl.java:261)
    at com.sun.enterprise.connectors.util.ConnectorJavaBeanValidator.validateJavaBean(ConnectorJavaBeanValidator.java:66)
    at com.sun.enterprise.connectors.service.ConnectorConnectionPoolAdminServiceImpl.validateMCF(ConnectorConnectionPoolAdminServiceImpl.java:984)
    at com.sun.enterprise.connectors.service.ConnectorConnectionPoolAdminServiceImpl.obtainManagedConnectionFactory(ConnectorConnectionPoolAdminServiceImpl.java:1016)
    at com.sun.enterprise.connectors.service.ConnectorConnectionPoolAdminServiceImpl.obtainManagedConnectionFactory(ConnectorConnectionPoolAdminServiceImpl.java:989)
    at com.sun.enterprise.connectors.service.ConnectorConnectionPoolAdminServiceImpl.createConnectorConnectionPool(ConnectorConnectionPoolAdminServiceImpl.java:188)
    at com.sun.enterprise.connectors.ConnectorRuntime.createConnectorConnectionPool(ConnectorRuntime.java:331)
    at com.sun.enterprise.connectors.ActiveResourceAdapterImpl.createDefaultConnectorConnectionPools(ActiveResourceAdapterImpl.java:478)
    at com.sun.enterprise.connectors.ActiveResourceAdapterImpl.createAllConnectorResources(ActiveResourceAdapterImpl.java:183)
    at com.sun.enterprise.connectors.ActiveOutboundResourceAdapter.setup(ActiveOutboundResourceAdapter.java:239)
    at com.sun.enterprise.connectors.service.ResourceAdapterAdminServiceImpl.createActiveResourceAdapter(ResourceAdapterAdminServiceImpl.java:237)
    at com.sun.enterprise.connectors.ConnectorRuntime.createActiveResourceAdapter(ConnectorRuntime.java:412)
    at com.sun.enterprise.connectors.module.ConnectorDeployer.load(ConnectorDeployer.java:197)
    at com.sun.enterprise.connectors.module.ConnectorDeployer.load(ConnectorDeployer.java:92)
    at org.glassfish.internal.data.ModuleInfo.load(ModuleInfo.java:206)
    at org.glassfish.internal.data.ApplicationInfo.load(ApplicationInfo.java:313)
    at com.sun.enterprise.v3.server.ApplicationLifecycle.deploy(ApplicationLifecycle.java:493)
    at com.sun.enterprise.v3.server.ApplicationLifecycle.deploy(ApplicationLifecycle.java:219)
    at org.glassfish.deployment.admin.DeployCommand.execute(DeployCommand.java:491)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:527)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl$2$1.run(CommandRunnerImpl.java:523)
    at java.security.AccessController.doPrivileged(Native Method)
    at javax.security.auth.Subject.doAs(Subject.java:356)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl$2.execute(CommandRunnerImpl.java:522)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:546)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl.doCommand(CommandRunnerImpl.java:1423)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl.access$1500(CommandRunnerImpl.java:108)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1762)
    at com.sun.enterprise.v3.admin.CommandRunnerImpl$ExecutionContext.execute(CommandRunnerImpl.java:1674)
    at org.glassfish.admin.rest.utils.ResourceUtil.runCommand(ResourceUtil.java:235)
    at org.glassfish.admin.rest.utils.ResourceUtil.runCommand(ResourceUtil.java:257)
    at org.glassfish.admin.rest.resources.TemplateListOfResource.createResource(TemplateListOfResource.java:134)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:606)
    at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory$1.invoke(ResourceMethodInvocationHandlerFactory.java:81)
    at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:125)
    at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$ResponseOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:152)
    at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:91)
    at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:346)
    at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:341)
    at org.glassfish.jersey.server.model.ResourceMethodInvoker.apply(ResourceMethodInvoker.java:101)
    at org.glassfish.jersey.server.ServerRuntime$1.run(ServerRuntime.java:224)
    at org.glassfish.jersey.internal.Errors$1.call(Errors.java:271)
    at org.glassfish.jersey.internal.Errors$1.call(Errors.java:267)
    at org.glassfish.jersey.internal.Errors.process(Errors.java:315)
    at org.glassfish.jersey.internal.Errors.process(Errors.java:297)
    at org.glassfish.jersey.internal.Errors.process(Errors.java:267)
    at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:317)
    at org.glassfish.jersey.server.ServerRuntime.process(ServerRuntime.java:198)
    at org.glassfish.jersey.server.ApplicationHandler.handle(ApplicationHandler.java:946)
    at org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpContainer.service(GrizzlyHttpContainer.java:331)
    at org.glassfish.admin.rest.adapter.RestAdapter$2.service(RestAdapter.java:318)
    at org.glassfish.admin.rest.adapter.RestAdapter.service(RestAdapter.java:181)
    at com.sun.enterprise.v3.services.impl.ContainerMapper.service(ContainerMapper.java:246)
    at org.glassfish.grizzly.http.server.HttpHandler.runService(HttpHandler.java:191)
    at org.glassfish.grizzly.http.server.HttpHandler.doHandle(HttpHandler.java:168)
    at org.glassfish.grizzly.http.server.HttpServerFilter.handleRead(HttpServerFilter.java:189)
    at org.glassfish.grizzly.filterchain.ExecutorResolver$9.execute(ExecutorResolver.java:119)
    at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeFilter(DefaultFilterChain.java:288)
    at org.glassfish.grizzly.filterchain.DefaultFilterChain.executeChainPart(DefaultFilterChain.java:206)
    at org.glassfish.grizzly.filterchain.DefaultFilterChain.execute(DefaultFilterChain.java:136)
    at org.glassfish.grizzly.filterchain.DefaultFilterChain.process(DefaultFilterChain.java:114)
    at org.glassfish.grizzly.ProcessorExecutor.execute(ProcessorExecutor.java:77)
    at org.glassfish.grizzly.nio.transport.TCPNIOTransport.fireIOEvent(TCPNIOTransport.java:838)
    at org.glassfish.grizzly.strategies.AbstractIOStrategy.fireIOEvent(AbstractIOStrategy.java:113)
    at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.run0(WorkerThreadIOStrategy.java:115)
    at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy.access$100(WorkerThreadIOStrategy.java:55)
    at org.glassfish.grizzly.strategies.WorkerThreadIOStrategy$WorkerThreadRunnable.run(WorkerThreadIOStrategy.java:135
    at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.doWork(AbstractThreadPool.java:564)
    at org.glassfish.grizzly.threadpool.AbstractThreadPool$Worker.run(AbstractThreadPool.java:544)
    at java.lang.Thread.run(Thread.java:744)
]]
```
