### PR TITLE
Fixes BeanValidation annotation for work-manager.

### DIFF
--- a/jca-work-manager/work-manager-ra/src/main/java/org/connectorz/workmanager/ConnectionFactory.java
+++ b/jca-work-manager/work-manager-ra/src/main/java/org/connectorz/workmanager/ConnectionFactory.java
@@ -25,7 +25,8 @@ import javax.resource.ResourceException;
 import javax.resource.spi.*;
 import javax.resource.spi.work.WorkManager;
 import javax.security.auth.Subject;
-import javax.validation.constraints.Size;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 /**
  * @author adam bien, adam-bien.com
  */
@@ -40,7 +41,9 @@ public class ConnectionFactory
     private LogWriter log;
     private PrintWriter out;
     private WorkManagerBootstrap workManagerAdapter;
-    private int maxNumberOfConcurrentRequests;
+    @NotNull
+    @Min(1)
+    private Integer maxNumberOfConcurrentRequests;
     
 
     public ConnectionFactory() {
@@ -48,13 +51,12 @@ public class ConnectionFactory
         log.println("#ConnectionFactory.constructor");
     }
 
-    @Size(min = 1)
     @ConfigProperty(defaultValue = "2", supportsDynamicUpdates = true, description = "Maximum number of concurrent connections from different processes that an EIS instance can supportMaximum number of concurrent connections from different processes that an EIS instance can support")
     public void setMaxNumberOfConcurrentRequests(Integer maxNumberOfConcurrentRequests) {
         this.maxNumberOfConcurrentRequests = maxNumberOfConcurrentRequests;
     }
 
-    public int getMaxNumberOfConcurrentRequests() {
+    public Integer getMaxNumberOfConcurrentRequests() {
         return maxNumberOfConcurrentRequests;
     }
 


### PR DESCRIPTION
Fixes the BeanValidation Annotation on the work-manager JCA connector. It does belong at the Field or Getter and not the Setter.

Because the current code mixes int and Integer another problem occured. Because JCA requires Integer in the Setter I changed the Field and Getter to Integer.
